### PR TITLE
[TEST ONLY] enable ci works on every pr to main.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: CI to Verify setup.sh
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,14 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run environment_mac.sh
         run: bash environment_mac.sh


### PR DESCRIPTION
This PR is for TEST ONLY. 
Please DO NOT merge it.

实现了github  action  的第一版，增加.github/workflow/main.yml。这样以后每次对main分支进行commit的时候，都会启动ci来进行验证。验证结果会直接显示在项目主页上。
目前只是对envinment.sh 进行了验证，有兴趣的可以逐步去完善它。

**Run Environment_mac.sh**
主要是 github提供的ubuntu，brew, build-essential,  npm和 rustup都是自带的。
(参见：https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)
所以只需要6mins去把其余的安装了，环境就设置好了。以后可以把设置好的环境dump出来直接使用，这样就省下这6mins了。
(参见：https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners)
(参见：https://docs.microsoft.com/en-us/azure/developer/github/build-vm-image)

**Run setup.sh**
这个ci代码里面，对于setup.sh 的验证是不对的，因为没有为ci设置权限，导致其余的依赖都没办法顺利拉下来。这点以后慢慢完善吧。
